### PR TITLE
Switch to using openjdk-alpine and bump ghidra to 9.1 (dev)

### DIFF
--- a/start_server.sh
+++ b/start_server.sh
@@ -1,13 +1,4 @@
 #!/bin/bash
 
-new_password=true
-if [ -z $NEW_PASSWORD ]; then
-    new_password=false
-fi
-if [ "$new_password" == true ]; then
-    echo $PASSWORD | sudo -S sh -c "echo \"ghidra:$NEW_PASSWORD\" | chpasswd"
-    PASSWORD=$NEW_PASSWORD
-fi
-
 cd $GHIDRA_INSTALL_PATH/ghidra/server
-echo $PASSWORD | sudo -S "PATH=$PATH" ./ghidraSvr console
+echo $PASSWORD | ./ghidraSvr console


### PR DESCRIPTION
Switched over to openjdk-alpine in an attempt to minimize the
size of the images (it worked, a little bit) and bump to the latest
version of ghidra 9.1.