### PR TITLE
Move server.conf into repository storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,9 +28,9 @@ RUN wget --progress=bar:force -O ghidra_${GHIDRA_VERSION}.zip ${GHIDRA_RELEASE_U
 
 # Install Ghidra server.
 RUN cd ${GHIDRA_INSTALL_PATH}/ghidra/server && \
-    cp server.conf server.conf.bak && \
     mkdir -p ${GHIDRA_REPOS_PATH} && \
-    sed 's|ghidra.repositories.dir=.*|ghidra.repositories.dir='"${GHIDRA_REPOS_PATH}"'|' server.conf.bak > server.conf && \
+    sed 's|ghidra.repositories.dir=.*|ghidra.repositories.dir='"${GHIDRA_REPOS_PATH}"'|' server.conf > ${GHIDRA_REPOS_PATH}/server.conf && \
+    rm server.conf && ln -s ${GHIDRA_REPOS_PATH}/server.conf server.conf && \
     ${GHIDRA_INSTALL_PATH}/ghidra/server/svrInstall && \
     chown -R ghidra: ${GHIDRA_REPOS_PATH} && \
     cd /home/ghidra && \


### PR DESCRIPTION
This allows modifying the server config to allow for customization (like enabling anonymous access or asking for user ids).
This prevents having to modify the container to do so, which makes deployment and potential updates a lot easier.